### PR TITLE
feat: 주문 생성(POST) 최소 기능 구현 #6

### DIFF
--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,0 +1,38 @@
+package com.pcproject.order.controller;
+
+
+import com.pcproject.order.dto.CreateOrderRequest;
+import com.pcproject.order.dto.CreateOrderResponse;
+import com.pcproject.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 20.
+ * Time: 오후 7:57
+ **/
+
+@RequestMapping("/api/orders")
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    // 주문 생성(POST)
+    @PostMapping
+    public ResponseEntity<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
+        CreateOrderResponse result = orderService.createOrder(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+
+}

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -1,0 +1,33 @@
+package com.pcproject.order.dto;
+
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 20.
+ * Time: 오후 8:07
+ **/
+
+@Getter
+@NoArgsConstructor
+public class CreateOrderRequest {
+
+    @NotNull
+    private Long customerId;
+
+    @NotNull
+    private Long productId;
+
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+
+    // 요청 or 인증 추출
+    // private Long adminId;
+
+}

--- a/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
@@ -1,0 +1,36 @@
+package com.pcproject.order.dto;
+
+
+import com.pcproject.order.entity.OrderStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 20.
+ * Time: 오후 8:07
+ **/
+
+@Getter
+public class CreateOrderResponse {
+
+    private final Long orderId;
+    private final String orderNumber;
+    private final OrderStatus status;
+    private final Integer quantity;
+    private final Long unitPrice;
+    private final Long totalAmount;
+    private final LocalDateTime createdAt;
+
+    public CreateOrderResponse(Long orderId, String orderNumber, OrderStatus status, Integer quantity, Long unitPrice, Long totalAmount, LocalDateTime createdAt) {
+        this.orderId = orderId;
+        this.orderNumber = orderNumber;
+        this.status = status;
+        this.quantity = quantity;
+        this.unitPrice = unitPrice;
+        this.totalAmount = totalAmount;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/pcproject/order/repository/OrderRepository.java
+++ b/src/main/java/com/pcproject/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.pcproject.order.repository;
+
+import com.pcproject.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,0 +1,63 @@
+package com.pcproject.order.service;
+
+
+import com.pcproject.order.dto.CreateOrderRequest;
+import com.pcproject.order.dto.CreateOrderResponse;
+import com.pcproject.order.entity.Order;
+import com.pcproject.order.entity.OrderStatus;
+import com.pcproject.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 20.
+ * Time: 오후 7:59
+ **/
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // 주문 생성(POST)
+    @Transactional
+    public CreateOrderResponse createOrder(CreateOrderRequest request) {
+
+        // 주문번호(임시) ORD-생성시간-랜덤
+        String orderNumber =
+                "ORD-" + System.currentTimeMillis()
+                + "-" + UUID.randomUUID().toString().substring(0, 4);
+
+        // 상품 가격(임시)
+        Long unitPrice = 10000L;
+
+        // 관리자 Id 임시로 null값 넣음
+        Order order = new Order(
+                orderNumber,
+                request.getCustomerId(),
+                request.getProductId(),
+                null,
+                request.getQuantity(),
+                unitPrice,
+                OrderStatus.PREPARING
+        );
+
+        Order savedOrder = orderRepository.save(order);
+
+        return new CreateOrderResponse(
+                savedOrder.getId(),
+                savedOrder.getOrderNumber(),
+                savedOrder.getStatus(),
+                savedOrder.getQuantity(),
+                savedOrder.getUnitPrice(),
+                savedOrder.getTotalAmount(),
+                savedOrder.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
Summary
- 주문 생성 API(POST) 최소 기능 구현 및 기본 주문 생성 흐름 구축

Closes
Closes #6

Changes
- API 추가: POST /api/orders 주문 생성 엔드포인트 구현
- DTO 정의: CreateOrderRequest, CreateOrderResponse 생성
- 서비스 로직: 주문번호 생성(임시), 초기 상태 PREPARING 설정, 주문 저장 및 응답 반환
- 검증 적용: CreateOrderRequest에 @NotNull, @Min(1) 적용 및 컨트롤러 @Valid 적용

참고 사항
- 현재 단계에서는 상품 가격(unitPrice)을 임시값으로 사용하고 있습니다. (추후 상품 연동 시 실제 가격 스냅샷 저장으로 변경 예정)
- adminId는 인증 연동 전이라 null로 처리했습니다. (CS 대리 주문/관리자 인증 연동 시 반영 예정)
- 재고 검증/차감 및 상품 상태(ON_SALE/SOLD_OUT 등) 반영은 후속 작업에서 추가 예정입니다.