### PR TITLE
feat: 주문 취소 기능(PATCH) 최소 기능 구현 #17

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="25" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="homebrew-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -3,12 +3,15 @@ package com.pcproject.order.controller;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 
+@Validated
 @RequestMapping("/api/orders")
 @RestController
 @RequiredArgsConstructor
@@ -26,12 +29,22 @@ public class OrderController {
     // 주문 상태 수정(PATCH)
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
-            @PathVariable Long orderId,
+            @PathVariable @Positive Long orderId,
             @Valid @RequestBody UpdateOrderRequest request) {
 
         UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
+
+    // 주문 취소(PATCH)
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<CancelOrderResponse> cancelOrder(
+            @PathVariable @Positive Long orderId,
+            @Valid @RequestBody CancelOrderRequest request) {
+        CancelOrderResponse result = orderService.cancelOrder(orderId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
 
     @GetMapping
     public ResponseEntity<OrderListResponse> getOrders(OrderSearchRequest request) {

--- a/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
@@ -1,0 +1,19 @@
+package com.pcproject.order.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 23.
+ * Time: 오후 3:34
+ **/
+
+@Getter
+public class CancelOrderRequest {
+
+    @NotBlank
+    private String cancelReason;
+}

--- a/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
@@ -1,0 +1,31 @@
+package com.pcproject.order.dto;
+
+
+import com.pcproject.order.entity.OrderStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: jeongjihun
+ * Date: 26. 2. 23.
+ * Time: 오후 3:35
+ **/
+
+
+@Getter
+public class CancelOrderResponse {
+
+    private final Long orderId;
+    private final OrderStatus status;
+    private final String cancelReason;
+    private final LocalDateTime updatedAt;
+
+    public CancelOrderResponse(Long orderId, OrderStatus status, String cancelReason, LocalDateTime updatedAt) {
+        this.orderId = orderId;
+        this.status = status;
+        this.cancelReason = cancelReason;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -71,8 +71,16 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
+    // 주문 상태 변경 메서드
     public void updateStatus(OrderStatus status) {
         this.status = status;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 주문 취소 메서드
+    public void cancel(String cancelReason) {
+        this.status = OrderStatus.CANCELLED;
+        this.cancelReason = cancelReason;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -8,6 +8,7 @@ import com.pcproject.order.entity.Order;
 import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,9 +30,6 @@ public class OrderService {
     // 주문 생성(POST)
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderRequest request) {
-
-        // 예외 처 - 고객 아이디
-
 
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =
@@ -65,6 +63,7 @@ public class OrderService {
         );
     }
 
+    // 주문 상태 변경(PATCH)
     @Transactional
     public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
 
@@ -89,13 +88,50 @@ public class OrderService {
             throw new IllegalStateException("INVALID_ORDER_STATUS");
         }
 
-        // 4) 상태 변경 + updatedAt 갱신 (엔티티 메서드로 하는 게 좋음)
+        // 4) 상태 변경 + updatedAt 갱신
         order.updateStatus(target);
 
         // 5) 저장
         orderRepository.save(order);
 
-        return new UpdateOrderResponse(order.getId(), order.getStatus(), order.getUpdatedAt());
+        return new UpdateOrderResponse(
+                order.getId(),
+                order.getStatus(),
+                order.getUpdatedAt()
+        );
+    }
+
+
+
+    // 주문 취소(PATCH)
+    @Transactional
+    public CancelOrderResponse cancelOrder(Long orderId, CancelOrderRequest request) {
+
+        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+
+        // 2) PREPARING만 취소 가능(추후 공통 에러 코드로 변경 예정)
+        if (order.getStatus() != OrderStatus.PREPARING) {
+            throw new IllegalStateException("ORDER_CANCEL_NOT_ALLOWED");
+        }
+
+        // 3) 취소 사유 저장 + 상태 변경
+        order.cancel(request.getCancelReason());
+
+        // 4) TODO: 재고 복구 처리(추후 구현 예정)
+        // - 주문 수량만큼 product.stock += quantity
+        // - product.status 자동 전환 (단, DISCONTINUED면 상태 유지)
+
+        // 5) 저장
+        orderRepository.save(order);
+
+        return new CancelOrderResponse(
+                order.getId(),
+                order.getStatus(),
+                order.getCancelReason(),
+                order.getUpdatedAt()
+        );
     }
 
 
@@ -129,7 +165,5 @@ public class OrderService {
 
         return OrderDetailResponse.from(order);
     }
-
-
 
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -30,6 +30,9 @@ public class OrderService {
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderRequest request) {
 
+        // 예외 처 - 고객 아이디
+
+
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =
                 "ORD-" + System.currentTimeMillis()


### PR DESCRIPTION
Summary
- 주문 취소 기능(PATCH) 최소 구현

Closes #17


Changes
- 주문 취소 API 구현: PATCH /api/orders/{orderId}/cancel
- 컨트롤러 추가: 주문 취소 엔드포인트 및 요청 처리 로직 구현
- DTO 정의:
CancelOrderRequest
CancelOrderResponse
- 서비스 로직 구현:
주문 ID로 주문 조회
PREPARING 상태에서만 취소 가능하도록 검증
취소 시 상태를 CANCELLED로 변경
취소 사유(cancelReason) 저장
updatedAt 갱신
- 주문 상태 전이 정책 반영:
CANCELLED 이후 상태 변경 불가


참고 사항
- 현재는 최소 기능 구현(MVP) 단계로, 다음 기능은 추후 구현 예정입니다:
상품 재고 복구 로직
상품 상태 자동 전환 처리
공통 예외 코드(CustomException) 적용
세션 기반 관리자 인증 연동
- 주문 취소는 요구사항에 따라 PREPARING 상태에서만 허용됩니다.