### PR TITLE
feat: 주문 상태 변경 로직 개선 및 전이 정책 캡슐화 #41

### DIFF
--- a/src/main/java/com/pcproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/pcproject/global/exception/ErrorCode.java
@@ -27,14 +27,16 @@ public enum ErrorCode {
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "단종된 상품입니다."),
-    PRODUCT_SOLD_OUT(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
-    PRODUCT_STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+    PRODUCT_DISCONTINUED(HttpStatus.CONFLICT, "단종된 상품입니다."),
+    PRODUCT_SOLD_OUT(HttpStatus.CONFLICT, "품절된 상품입니다."),
+    PRODUCT_STOCK_INSUFFICIENT(HttpStatus.CONFLICT, "재고가 부족합니다."),
+    PRODUCT_NOT_ON_SALE(HttpStatus.CONFLICT, "판매 중인 상품이 아닙니다."),
 
     // 주문
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
-    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "준비중 상태의 주문만 취소할 수 있습니다."),
-    ORDER_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다.");
+    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "준비중 상태의 주문만 취소할 수 있습니다."),
+    ORDER_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다."),
+    ORDER_INVALID_STATUS(HttpStatus.CONFLICT, "현재 주문 상태에서는 수행할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,7 +1,10 @@
 package com.pcproject.order.controller;
 
+import com.pcproject.admin.controller.SessionConst;
+import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +22,16 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    // 주문 생성(POST)
+    // 주문 생성 (세션 기반 관리자 인증)
     @PostMapping
-    public ResponseEntity<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
-        CreateOrderResponse result = orderService.createOrder(request);
+    public ResponseEntity<CreateOrderResponse> createOrder(
+            @Valid @RequestBody CreateOrderRequest request,
+            HttpSession session) {
+
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        CreateOrderResponse result = orderService.createOrder(request, loginAdmin);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -20,10 +20,10 @@ import lombok.NoArgsConstructor;
 public class CreateOrderRequest {
 
     @NotNull
-    private Customer customerId;
+    private Long customerId;
 
     @NotNull
-    private Product productId;
+    private Long productId;
 
     @NotNull
     @Min(1)

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
@@ -5,12 +5,6 @@ import com.pcproject.order.entity.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderRequest {

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
@@ -6,12 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderResponse {

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -2,6 +2,8 @@ package com.pcproject.order.entity;
 
 import com.pcproject.admin.entity.Admin;
 import com.pcproject.customer.entity.Customer;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import com.pcproject.pcproduct.entity.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -67,16 +69,34 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 주문 상태 변경 메서드
-    public void updateStatus(OrderStatus status) {
-        this.status = status;
-        this.updatedAt = LocalDateTime.now();
-    }
-
     // 주문 취소 메서드
     public void cancel(String cancelReason) {
         this.status = OrderStatus.CANCELLED;
         this.cancelReason = cancelReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 상태 전이 정책을 캡슐화한 메서드 (허용된 전이만 가능)
+    public void changeStatus(OrderStatus target) {
+
+        if (target == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (this.status == OrderStatus.CANCELLED
+                || this.status == OrderStatus.DELIVERED) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        boolean valid =
+                (this.status == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
+                        (this.status == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
+
+        if (!valid) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        this.status = target;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -102,32 +102,12 @@ public class OrderService {
     @Transactional
     public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
 
-        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        // 주문 조회(공통 에러 코드로 변경함)
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2) 최종 상태면 변경 불가(추후 공통 에러 코드로 변경 예정)
-        if (order.getStatus() == OrderStatus.CANCELLED || order.getStatus() == OrderStatus.DELIVERED) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        OrderStatus target = request.getStatus();
-        OrderStatus current = order.getStatus();
-
-        // 3) 허용된 전이만 통과
-        boolean isValid =
-                (current == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
-                        (current == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
-
-        if (!isValid) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        // 4) 상태 변경 + updatedAt 갱신
-        order.updateStatus(target);
-
-        // 5) 저장
-        orderRepository.save(order);
+        // 상태 전이 검증 및 변경은 도메인 정책에 따라 엔티티에서 처리
+        order.changeStatus(request.getStatus());
 
         return new UpdateOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.pcproject.order.service;
 
+import com.pcproject.customer.entity.Customer;
+import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
 import com.pcproject.global.exception.CustomException;
 import com.pcproject.global.exception.ErrorCode;
@@ -8,7 +10,8 @@ import com.pcproject.order.entity.Order;
 import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
-import jakarta.validation.Valid;
+import com.pcproject.pcproduct.entity.Product;
+import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,10 +29,20 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final CustomerRepository customerRepository;
+    private final ProductRepository productRepository;
 
     // 주문 생성(POST)
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderRequest request) {
+
+        // 고객 id 검증 및 공통 에러 처리
+        Customer customer = customerRepository.findById(request.getCustomerId())
+                .orElseThrow(()-> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+
+        // 상품 id 검증 및 공통 에러 처리
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =
@@ -42,8 +55,8 @@ public class OrderService {
         // 관리자 Id 임시로 null값 넣음
         Order order = new Order(
                 orderNumber,
-                request.getCustomerId(),
-                request.getProductId(),
+                customer,
+                product,
                 null,
                 request.getQuantity(),
                 unitPrice,

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,5 +1,8 @@
 package com.pcproject.order.service;
 
+import com.pcproject.admin.dto.LoginAdmin;
+import com.pcproject.admin.entity.Admin;
+import com.pcproject.admin.repository.AdminRepository;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
@@ -31,10 +34,20 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CustomerRepository customerRepository;
     private final ProductRepository productRepository;
+    private final AdminRepository adminRepository;
 
     // 주문 생성(POST)
     @Transactional
-    public CreateOrderResponse createOrder(CreateOrderRequest request) {
+    public CreateOrderResponse createOrder(CreateOrderRequest request, LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        Admin admin = adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 고객 id 검증 및 공통 에러 처리
         Customer customer = customerRepository.findById(request.getCustomerId())
@@ -61,12 +74,12 @@ public class OrderService {
         // 상품 가격 스냅샷
         Long unitPrice = product.getPrice();
 
-        // 관리자 Id 임시로 null값 넣음
+        // 주문 생성 (로그인 관리자 정보 포함)
         Order order = new Order(
                 orderNumber,
                 customer,
                 product,
-                null,
+                admin,
                 request.getQuantity(),
                 unitPrice,
                 OrderStatus.PREPARING

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
 import com.pcproject.pcproduct.entity.Product;
+import com.pcproject.pcproduct.entity.ProductStatus;
 import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,6 +44,29 @@ public class OrderService {
         // 상품 id 검증 및 공통 에러 처리
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // DTO와 함께 quantity 중복 체크(혹시 모를 우회 완전 차단)
+        if (request.getQuantity() < 1) {
+            throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
+        }
+
+        // 상품 삭제 여부 검증
+        if (product.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 판매 상태가 ON_SALE인지 확인
+        if (product.getStatus() != ProductStatus.ON_SALE) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
+        }
+
+        //
+        if (product.getStock() < request.getQuantity()) {
+            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
+        }
+
+        // 재고가 있는지 검증 후 차감
+        product.decreaseStock(request.getQuantity());
 
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -50,22 +50,8 @@ public class OrderService {
             throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
         }
 
-        // 상품 삭제 여부 검증
-        if (product.getDeletedAt() != null) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
-        }
-
-        // 판매 상태가 ON_SALE인지 확인
-        if (product.getStatus() != ProductStatus.ON_SALE) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
-        }
-
-        //
-        if (product.getStock() < request.getQuantity()) {
-            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
-        }
-
-        // 재고가 있는지 검증 후 차감
+        // 재고가 상태 검증 후 차감
+        product.validateOrderable();
         product.decreaseStock(request.getQuantity());
 
         // 주문번호(임시) ORD-생성시간-랜덤
@@ -73,8 +59,8 @@ public class OrderService {
                 "ORD-" + System.currentTimeMillis()
                 + "-" + UUID.randomUUID().toString().substring(0, 4);
 
-        // 상품 가격(임시)
-        Long unitPrice = 10000L;
+        // 상품 가격 스냅샷
+        Long unitPrice = product.getPrice();
 
         // 관리자 Id 임시로 null값 넣음
         Order order = new Order(

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -1,7 +1,11 @@
 package com.pcproject.pcproduct.entity;
 
 import com.pcproject.admin.entity.Admin;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -69,5 +73,13 @@ public class Product {
     }
     public boolean isDeleted() {
         return deletedAt != null;
+    }
+
+    // 재고 검증과 차감 메서드
+    public void decreaseStock(int quantity) {
+        if (this.stock < quantity) {
+            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
+        }
+        this.stock -= quantity;
     }
 }

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -75,11 +75,33 @@ public class Product {
         return deletedAt != null;
     }
 
+
+    // 재고 상태 검증
+    public void validateOrderable() {
+
+        // 상품 삭제 여부 검증
+        if (this.isDeleted()) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 판매 상태가 ON_SALE인지 확인
+        if (this.status != ProductStatus.ON_SALE) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
+        }
+    }
+
     // 재고 검증과 차감 메서드
     public void decreaseStock(int quantity) {
         if (this.stock < quantity) {
             throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
         }
         this.stock -= quantity;
+
+        // 재고가 0이 되면 자동으로 SOLD_OUT 전환
+        if (this.stock == 0 && this.status == ProductStatus.ON_SALE) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+
+        this.updatedAt = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
Summary
- 주문 상태 변경(Update) API의 상태 전이 검증 로직을 Service 레이어에서 Order 엔티티로 이동하여 도메인 정책을 캡슐화했습니다.
- 기존 updateStatus() 메서드를 제거하고, 상태 변경은 changeStatus()를 통해서만 가능하도록 구조를 정리했습니다.
- 허용된 상태 전이만 가능하도록 엔티티 내부에서 전이 검증 및 updatedAt 갱신을 수행하도록 개선했습니다.

Closes #41

Changes
1. 주문 상태 변경 서비스 로직 단순화 (OrderService#updateOrderStatus)
- 상태 전이 분기 로직 제거
- 상태 변경을 Order.changeStatus()로 위임
- CustomException + ErrorCode 기반 예외 처리로 통일
- Service는 흐름 제어 역할만 수행하도록 구조 정리

2. Order 엔티티 리팩토링
- changeStatus(OrderStatus target) 메서드 추가
null 방어 (INVALID_INPUT)
최종 상태(CANCELLED, DELIVERED) 변경 불가 처리
허용된 전이만 가능하도록 정책 명시
상태 변경 시 updatedAt 자동 갱신
- 기존 updateStatus() 메서드 제거
- 상태 전이 정책을 엔티티 내부로 이동

구조 개선 효과
- 상태 전이 정책이 Service에서 제거되어 도메인 책임이 명확해짐
- 비즈니스 규칙이 엔티티에 집중되어 유지보수성과 확장성 향상

참고 사항
- 문제 요구사항에 따라 주문 상태 전이 순서를
PREPARING → SHIPPING → DELIVERED 로 제한했습니다.
- CANCELLED, DELIVERED 상태에서는 추가 상태 변경이 불가하도록 처리했습니다.