### PR TITLE
feat: 주문 취소 API 세션 인증 적용 #52

### DIFF
--- a/src/main/java/com/pcproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/pcproject/global/exception/ErrorCode.java
@@ -27,14 +27,16 @@ public enum ErrorCode {
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "단종된 상품입니다."),
-    PRODUCT_SOLD_OUT(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
-    PRODUCT_STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+    PRODUCT_DISCONTINUED(HttpStatus.CONFLICT, "단종된 상품입니다."),
+    PRODUCT_SOLD_OUT(HttpStatus.CONFLICT, "품절된 상품입니다."),
+    PRODUCT_STOCK_INSUFFICIENT(HttpStatus.CONFLICT, "재고가 부족합니다."),
+    PRODUCT_NOT_ON_SALE(HttpStatus.CONFLICT, "판매 중인 상품이 아닙니다."),
 
     // 주문
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
-    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "준비중 상태의 주문만 취소할 수 있습니다."),
-    ORDER_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다.");
+    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "준비중 상태의 주문만 취소할 수 있습니다."),
+    ORDER_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다."),
+    ORDER_INVALID_STATUS(HttpStatus.CONFLICT, "현재 주문 상태에서는 수행할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -39,9 +39,13 @@ public class OrderController {
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
             @PathVariable @Positive Long orderId,
-            @Valid @RequestBody UpdateOrderRequest request) {
+            @Valid @RequestBody UpdateOrderRequest request,
+            HttpSession session) {
 
-        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request);
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, loginAdmin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -35,7 +35,7 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
-    // 주문 상태 수정(PATCH)
+    // 주문 상태 수정 (세션 기반 관리자 인증)
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
             @PathVariable @Positive Long orderId,
@@ -49,12 +49,17 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    // 주문 취소(PATCH)
+    // 주문 취소 (세션 기반 관리자 인증)
     @PatchMapping("/{orderId}/cancel")
     public ResponseEntity<CancelOrderResponse> cancelOrder(
             @PathVariable @Positive Long orderId,
-            @Valid @RequestBody CancelOrderRequest request) {
-        CancelOrderResponse result = orderService.cancelOrder(orderId, request);
+            @Valid @RequestBody CancelOrderRequest request,
+            HttpSession session) {
+
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        CancelOrderResponse result = orderService.cancelOrder(orderId, request, loginAdmin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,7 +1,10 @@
 package com.pcproject.order.controller;
 
+import com.pcproject.admin.controller.SessionConst;
+import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +22,16 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    // 주문 생성(POST)
+    // 주문 생성 (세션 기반 관리자 인증)
     @PostMapping
-    public ResponseEntity<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
-        CreateOrderResponse result = orderService.createOrder(request);
+    public ResponseEntity<CreateOrderResponse> createOrder(
+            @Valid @RequestBody CreateOrderRequest request,
+            HttpSession session) {
+
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        CreateOrderResponse result = orderService.createOrder(request, loginAdmin);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
@@ -4,12 +4,6 @@ package com.pcproject.order.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오후 3:34
- **/
 
 @Getter
 public class CancelOrderRequest {

--- a/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
@@ -6,13 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오후 3:35
- **/
-
 
 @Getter
 public class CancelOrderResponse {

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -28,8 +28,4 @@ public class CreateOrderRequest {
     @NotNull
     @Min(1)
     private Integer quantity;
-
-    // 요청 or 인증 추출
-    // private Long adminId;
-
 }

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -20,10 +20,10 @@ import lombok.NoArgsConstructor;
 public class CreateOrderRequest {
 
     @NotNull
-    private Customer customerId;
+    private Long customerId;
 
     @NotNull
-    private Product productId;
+    private Long productId;
 
     @NotNull
     @Min(1)

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -8,12 +8,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 20.
- * Time: 오후 8:07
- **/
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
@@ -6,12 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 20.
- * Time: 오후 8:07
- **/
 
 @Getter
 public class CreateOrderResponse {

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
@@ -5,12 +5,6 @@ import com.pcproject.order.entity.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderRequest {

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
@@ -6,12 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderResponse {

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -69,12 +69,6 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 주문 취소 메서드
-    public void cancel(String cancelReason) {
-        this.status = OrderStatus.CANCELLED;
-        this.cancelReason = cancelReason;
-        this.updatedAt = LocalDateTime.now();
-    }
 
     // 상태 전이 정책을 캡슐화한 메서드 (허용된 전이만 가능)
     public void changeStatus(OrderStatus target) {
@@ -99,4 +93,23 @@ public class Order {
         this.status = target;
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 주문 취소 정책 수행 (사유 검증 + PREPARING 상태만 허용)
+    public void cancel(String cancelReason) {
+
+        // 취소 사유는 필수 (도메인 무결성 보장)
+        if (cancelReason == null || cancelReason.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        // 취소는 PREPARING 상태에서만 가능
+        if (this.status != OrderStatus.PREPARING) {
+            throw new CustomException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        }
+
+        this.status = OrderStatus.CANCELLED;
+        this.cancelReason = cancelReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -2,6 +2,8 @@ package com.pcproject.order.entity;
 
 import com.pcproject.admin.entity.Admin;
 import com.pcproject.customer.entity.Customer;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import com.pcproject.pcproduct.entity.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -67,16 +69,34 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 주문 상태 변경 메서드
-    public void updateStatus(OrderStatus status) {
-        this.status = status;
-        this.updatedAt = LocalDateTime.now();
-    }
-
     // 주문 취소 메서드
     public void cancel(String cancelReason) {
         this.status = OrderStatus.CANCELLED;
         this.cancelReason = cancelReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 상태 전이 정책을 캡슐화한 메서드 (허용된 전이만 가능)
+    public void changeStatus(OrderStatus target) {
+
+        if (target == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (this.status == OrderStatus.CANCELLED
+                || this.status == OrderStatus.DELIVERED) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        boolean valid =
+                (this.status == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
+                        (this.status == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
+
+        if (!valid) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        this.status = target;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -102,32 +102,12 @@ public class OrderService {
     @Transactional
     public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
 
-        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        // 주문 조회(공통 에러 코드로 변경함)
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2) 최종 상태면 변경 불가(추후 공통 에러 코드로 변경 예정)
-        if (order.getStatus() == OrderStatus.CANCELLED || order.getStatus() == OrderStatus.DELIVERED) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        OrderStatus target = request.getStatus();
-        OrderStatus current = order.getStatus();
-
-        // 3) 허용된 전이만 통과
-        boolean isValid =
-                (current == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
-                        (current == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
-
-        if (!isValid) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        // 4) 상태 변경 + updatedAt 갱신
-        order.updateStatus(target);
-
-        // 5) 저장
-        orderRepository.save(order);
+        // 상태 전이 검증 및 변경은 도메인 정책에 따라 엔티티에서 처리
+        order.changeStatus(request.getStatus());
 
         return new UpdateOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -140,9 +140,9 @@ public class OrderService {
         // 취소 사유 검증 및 저장, 상태 변경은 도메인 정책에 따라 엔티티에서 처리
         order.cancel(request.getCancelReason());
 
-        // 4) TODO: 재고 복구 처리(추후 구현 예정)
-        // - 주문 수량만큼 product.stock += quantity
-        // - product.status 자동 전환 (단, DISCONTINUED면 상태 유지)
+        // 취소된 주문 수량만큼 상품 재고 복구 (상품 도메인 정책 적용)
+        Product product = order.getProduct();
+        product.restoreStock(order.getQuantity());
 
         return new CancelOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -131,7 +131,19 @@ public class OrderService {
 
     // 주문 취소(PATCH)
     @Transactional
-    public CancelOrderResponse cancelOrder(Long orderId, CancelOrderRequest request) {
+    public CancelOrderResponse cancelOrder(
+            Long orderId,
+            CancelOrderRequest request,
+            LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -38,7 +38,9 @@ public class OrderService {
 
     // 주문 생성(POST)
     @Transactional
-    public CreateOrderResponse createOrder(CreateOrderRequest request, LoginAdmin loginAdmin) {
+    public CreateOrderResponse createOrder(
+            CreateOrderRequest request,
+            LoginAdmin loginAdmin) {
 
         // 세션 로그인 검증
         if (loginAdmin == null) {
@@ -100,7 +102,19 @@ public class OrderService {
 
     // 주문 상태 변경(PATCH)
     @Transactional
-    public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
+    public UpdateOrderResponse updateOrderStatus(
+            Long orderId,
+            UpdateOrderRequest request,
+            LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 주문 조회(공통 에러 코드로 변경함)
         Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.pcproject.order.service;
 
+import com.pcproject.customer.entity.Customer;
+import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
 import com.pcproject.global.exception.CustomException;
 import com.pcproject.global.exception.ErrorCode;
@@ -8,7 +10,8 @@ import com.pcproject.order.entity.Order;
 import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
-import jakarta.validation.Valid;
+import com.pcproject.pcproduct.entity.Product;
+import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,10 +29,20 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final CustomerRepository customerRepository;
+    private final ProductRepository productRepository;
 
     // 주문 생성(POST)
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderRequest request) {
+
+        // 고객 id 검증 및 공통 에러 처리
+        Customer customer = customerRepository.findById(request.getCustomerId())
+                .orElseThrow(()-> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+
+        // 상품 id 검증 및 공통 에러 처리
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =
@@ -42,8 +55,8 @@ public class OrderService {
         // 관리자 Id 임시로 null값 넣음
         Order order = new Order(
                 orderNumber,
-                request.getCustomerId(),
-                request.getProductId(),
+                customer,
+                product,
                 null,
                 request.getQuantity(),
                 unitPrice,

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,5 +1,8 @@
 package com.pcproject.order.service;
 
+import com.pcproject.admin.dto.LoginAdmin;
+import com.pcproject.admin.entity.Admin;
+import com.pcproject.admin.repository.AdminRepository;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
@@ -31,10 +34,20 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CustomerRepository customerRepository;
     private final ProductRepository productRepository;
+    private final AdminRepository adminRepository;
 
     // 주문 생성(POST)
     @Transactional
-    public CreateOrderResponse createOrder(CreateOrderRequest request) {
+    public CreateOrderResponse createOrder(CreateOrderRequest request, LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        Admin admin = adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 고객 id 검증 및 공통 에러 처리
         Customer customer = customerRepository.findById(request.getCustomerId())
@@ -61,12 +74,12 @@ public class OrderService {
         // 상품 가격 스냅샷
         Long unitPrice = product.getPrice();
 
-        // 관리자 Id 임시로 null값 넣음
+        // 주문 생성 (로그인 관리자 정보 포함)
         Order order = new Order(
                 orderNumber,
                 customer,
                 product,
-                null,
+                admin,
                 request.getQuantity(),
                 unitPrice,
                 OrderStatus.PREPARING

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
 import com.pcproject.pcproduct.entity.Product;
+import com.pcproject.pcproduct.entity.ProductStatus;
 import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,6 +44,29 @@ public class OrderService {
         // 상품 id 검증 및 공통 에러 처리
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // DTO와 함께 quantity 중복 체크(혹시 모를 우회 완전 차단)
+        if (request.getQuantity() < 1) {
+            throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
+        }
+
+        // 상품 삭제 여부 검증
+        if (product.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 판매 상태가 ON_SALE인지 확인
+        if (product.getStatus() != ProductStatus.ON_SALE) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
+        }
+
+        //
+        if (product.getStock() < request.getQuantity()) {
+            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
+        }
+
+        // 재고가 있는지 검증 후 차감
+        product.decreaseStock(request.getQuantity());
 
         // 주문번호(임시) ORD-생성시간-랜덤
         String orderNumber =

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -50,22 +50,8 @@ public class OrderService {
             throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
         }
 
-        // 상품 삭제 여부 검증
-        if (product.getDeletedAt() != null) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
-        }
-
-        // 판매 상태가 ON_SALE인지 확인
-        if (product.getStatus() != ProductStatus.ON_SALE) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
-        }
-
-        //
-        if (product.getStock() < request.getQuantity()) {
-            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
-        }
-
-        // 재고가 있는지 검증 후 차감
+        // 재고가 상태 검증 후 차감
+        product.validateOrderable();
         product.decreaseStock(request.getQuantity());
 
         // 주문번호(임시) ORD-생성시간-랜덤
@@ -73,8 +59,8 @@ public class OrderService {
                 "ORD-" + System.currentTimeMillis()
                 + "-" + UUID.randomUUID().toString().substring(0, 4);
 
-        // 상품 가격(임시)
-        Long unitPrice = 10000L;
+        // 상품 가격 스냅샷
+        Long unitPrice = product.getPrice();
 
         // 관리자 Id 임시로 null값 넣음
         Order order = new Order(

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -13,7 +13,6 @@ import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
 import com.pcproject.pcproduct.entity.Product;
-import com.pcproject.pcproduct.entity.ProductStatus;
 import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -116,7 +115,7 @@ public class OrderService {
         adminRepository.findById(loginAdmin.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        // 주문 조회(공통 에러 코드로 변경함)
+        // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
@@ -130,30 +129,20 @@ public class OrderService {
         );
     }
 
-
-
     // 주문 취소(PATCH)
     @Transactional
     public CancelOrderResponse cancelOrder(Long orderId, CancelOrderRequest request) {
 
-        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2) PREPARING만 취소 가능(추후 공통 에러 코드로 변경 예정)
-        if (order.getStatus() != OrderStatus.PREPARING) {
-            throw new IllegalStateException("ORDER_CANCEL_NOT_ALLOWED");
-        }
-
-        // 3) 취소 사유 저장 + 상태 변경
+        // 취소 사유 검증 및 저장, 상태 변경은 도메인 정책에 따라 엔티티에서 처리
         order.cancel(request.getCancelReason());
 
         // 4) TODO: 재고 복구 처리(추후 구현 예정)
         // - 주문 수량만큼 product.stock += quantity
         // - product.status 자동 전환 (단, DISCONTINUED면 상태 유지)
-
-        // 5) 저장
-        orderRepository.save(order);
 
         return new CancelOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -104,4 +104,28 @@ public class Product {
 
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 재고 복구 메서드
+    public void restoreStock(int quantity) {
+
+        if (quantity <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        this.stock += quantity;
+
+        // 단종(DISCONTINUED) 상품은 재고만 복구하고 상태는 변경하지 않음
+        if (this.status == ProductStatus.DISCONTINUED) {
+            this.updatedAt = LocalDateTime.now();
+            return;
+        }
+
+        // SOLD_OUT 상태에서 재고가 1 이상이면 ON_SALE로 전환
+        if (this.status == ProductStatus.SOLD_OUT && this.stock > 0) {
+            this.status = ProductStatus.ON_SALE;
+        }
+
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -1,7 +1,11 @@
 package com.pcproject.pcproduct.entity;
 
 import com.pcproject.admin.entity.Admin;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -69,5 +73,13 @@ public class Product {
     }
     public boolean isDeleted() {
         return deletedAt != null;
+    }
+
+    // 재고 검증과 차감 메서드
+    public void decreaseStock(int quantity) {
+        if (this.stock < quantity) {
+            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
+        }
+        this.stock -= quantity;
     }
 }

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -75,11 +75,33 @@ public class Product {
         return deletedAt != null;
     }
 
+
+    // 재고 상태 검증
+    public void validateOrderable() {
+
+        // 상품 삭제 여부 검증
+        if (this.isDeleted()) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 판매 상태가 ON_SALE인지 확인
+        if (this.status != ProductStatus.ON_SALE) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
+        }
+    }
+
     // 재고 검증과 차감 메서드
     public void decreaseStock(int quantity) {
         if (this.stock < quantity) {
             throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
         }
         this.stock -= quantity;
+
+        // 재고가 0이 되면 자동으로 SOLD_OUT 전환
+        if (this.stock == 0 && this.status == ProductStatus.ON_SALE) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+
+        this.updatedAt = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
Summary
- 주문 취소(Cancel) API에 세션 기반 관리자 인증을 적용했습니다.
- 로그인하지 않은 상태에서 주문 취소 요청 시 UNAUTHORIZED(401) 예외가 발생하도록 처리했습니다.
- 세션에 저장된 관리자 정보를 기반으로 관리자 존재 여부를 검증하도록 구현했습니다.

Closes #52

Changes
1. 주문 취소 컨트롤러 수정 (OrderController)
- HttpSession을 주입받아 세션에서 로그인 관리자 정보(LoginAdmin) 추출
- 상태 변경 및 주문 생성 API와 동일한 인증 구조 적용
- 주문 취소 API를 보호 API로 전환

2. 주문 취소 서비스 로직 수정 (OrderService#cancelOrder)
- 메서드 시그니처 변경
  cancelOrder(Long orderId, CancelOrderRequest request)
  → cancelOrder(Long orderId, CancelOrderRequest request, LoginAdmin loginAdmin)
- 세션 로그인 검증 로직 추가
- 로그인 정보가 없을 경우 UNAUTHORIZED 예외 발생
- 로그인 관리자 ID 기반으로 Admin 엔티티 존재 여부 검증

보호 정책
- 로그인하지 않은 사용자는 주문 취소 불가
- 세션에 저장된 관리자 정보만을 기준으로 인증 처리
- 주문 생성 / 상태 변경 / 취소 API에 동일한 인증 구조 적용

참고 사항
- 현재 프로젝트는 Spring Security가 아닌 HttpSession 기반 인증 구조를 사용합니다.
- 기존 주문 취소 정책(PREPARING 상태에서만 가능, 재고 복구 정책)은 그대로 유지됩니다.