### PR TITLE
feat: 관리자 인증/인가 인터셉터 구현 #58

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,9 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.pcproject.pcproject3.main.iml" filepath="$PROJECT_DIR$/.idea/modules/com.pcproject.pcproject3.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/pcproject3.iml" filepath="$PROJECT_DIR$/.idea/modules/pcproject3.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/pcproject3.main.iml" filepath="$PROJECT_DIR$/.idea/modules/pcproject3.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/pcproject3.test.iml" filepath="$PROJECT_DIR$/.idea/modules/pcproject3.test.iml" />
     </modules>
   </component>
 </project>

--- a/src/main/java/com/pcproject/global/config/WebConfig.java
+++ b/src/main/java/com/pcproject/global/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.pcproject.global.config;
+
+import com.pcproject.global.interceptor.AdminAuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AdminAuthInterceptor adminAuthInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(adminAuthInterceptor)
+                // 주문 생성
+                .addPathPatterns("/api/orders")
+                // 상태 변경
+                .addPathPatterns("/api/orders/*/status")
+                // 주문 취소
+                .addPathPatterns("/api/orders/*/cancel");
+    }
+}

--- a/src/main/java/com/pcproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/pcproject/global/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    INVALID_SORT_FIELD(HttpStatus.BAD_REQUEST, "허용되지 않은 정렬 기준입니다."),
+    INVALID_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 순서는 asc 또는 desc만 허용됩니다."),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지 크기는 100 이하이어야 합니다."),
 
     // 관리자
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다."),

--- a/src/main/java/com/pcproject/global/interceptor/AdminAuthInterceptor.java
+++ b/src/main/java/com/pcproject/global/interceptor/AdminAuthInterceptor.java
@@ -1,0 +1,65 @@
+package com.pcproject.global.interceptor;
+
+import com.pcproject.admin.controller.SessionConst;
+import com.pcproject.admin.dto.LoginAdmin;
+import com.pcproject.admin.entity.Admin;
+import com.pcproject.admin.entity.AdminRole;
+import com.pcproject.admin.repository.AdminRepository;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+
+@Component
+@RequiredArgsConstructor
+public class AdminAuthInterceptor implements HandlerInterceptor {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler) {
+
+        // 기존 세션이 있는지 확인 (새 세션 생성 방지)
+        HttpSession session = request.getSession(false);
+
+        // 세션이 없으면 로그인하지 않은 상태
+        if (session == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 세션에 저장된 로그인 관리자 정보 조회
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        // 로그인 정보가 없으면 인증 실패
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // CS_ADMIN 권한 검증
+        // 주문 CUD API는 CS 담당 관리자만 접근 가능
+        if (loginAdmin.getRole() != AdminRole.CS_ADMIN) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        // 실제 Admin 엔티티 조회
+        // 세션 DTO를 신뢰하지 않고 DB에서 다시 조회 (보안 강화)
+        Admin admin = adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        // 이후 Controller에서 사용할 수 있도록 request attribute에 저장
+        request.setAttribute("admin", admin);
+
+        // 인증/인가 성공 → Controller 진입 허용
+        return true;
+    }
+
+}

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -47,21 +47,14 @@ public class OrderController {
 
 
     @GetMapping
-    public ResponseEntity<OrderListResponse> getOrders(OrderSearchRequest request) {
-        OrderListResponse response = orderService.getOrders(
-                request.getKeyword(),
-                request.getStatus(),
-                request.getPage(),
-                request.getSize(),
-                request.getSortBy(),
-                request.getDirection()
-        );
+    public ResponseEntity<OrderListResponse> getOrders(@Valid OrderSearchRequest request) {
+        OrderListResponse response = orderService.getOrders(request);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<OrderDetailResponse> getOrder(@PathVariable Long id) {
-        OrderDetailResponse response = orderService.getOrder(id);
+    public ResponseEntity<OrderDetailResponse> getOrder(@PathVariable Long orderId) {
+        OrderDetailResponse response = orderService.getOrder(orderId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -39,9 +39,13 @@ public class OrderController {
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
             @PathVariable @Positive Long orderId,
-            @Valid @RequestBody UpdateOrderRequest request) {
+            @Valid @RequestBody UpdateOrderRequest request,
+            HttpSession session) {
 
-        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request);
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, loginAdmin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -35,7 +35,7 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
-    // 주문 상태 수정(PATCH)
+    // 주문 상태 수정 (세션 기반 관리자 인증)
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
             @PathVariable @Positive Long orderId,
@@ -49,12 +49,17 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    // 주문 취소(PATCH)
+    // 주문 취소 (세션 기반 관리자 인증)
     @PatchMapping("/{orderId}/cancel")
     public ResponseEntity<CancelOrderResponse> cancelOrder(
             @PathVariable @Positive Long orderId,
-            @Valid @RequestBody CancelOrderRequest request) {
-        CancelOrderResponse result = orderService.cancelOrder(orderId, request);
+            @Valid @RequestBody CancelOrderRequest request,
+            HttpSession session) {
+
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        CancelOrderResponse result = orderService.cancelOrder(orderId, request, loginAdmin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -2,8 +2,12 @@ package com.pcproject.order.controller;
 
 import com.pcproject.admin.controller.SessionConst;
 import com.pcproject.admin.dto.LoginAdmin;
+import com.pcproject.admin.entity.Admin;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -22,44 +26,54 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    // 주문 생성 (세션 기반 관리자 인증)
+    // Interceptor에서 주입된 Admin 추출 (방어적 null 체크)
+    private Admin extractAdmin(HttpServletRequest request) {
+        Admin admin = (Admin) request.getAttribute("admin");
+        if (admin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        return admin;
+    }
+
+    // 주문 생성 API
+    // 인증/인가 검증은 Interceptor에서 수행됨
     @PostMapping
     public ResponseEntity<CreateOrderResponse> createOrder(
             @Valid @RequestBody CreateOrderRequest request,
-            HttpSession session) {
+            HttpServletRequest httpRequest) {
 
-        LoginAdmin loginAdmin =
-                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+        Admin admin = extractAdmin(httpRequest);
 
-        CreateOrderResponse result = orderService.createOrder(request, loginAdmin);
+        CreateOrderResponse result = orderService.createOrder(request, admin);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
-    // 주문 상태 수정 (세션 기반 관리자 인증)
+    // 주문 상태 API
+    // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/status")
     public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody UpdateOrderRequest request,
-            HttpSession session) {
+            HttpServletRequest httpRequest) {
 
-        LoginAdmin loginAdmin =
-                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+        Admin admin = extractAdmin(httpRequest);
 
-        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, loginAdmin);
+        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, admin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    // 주문 취소 (세션 기반 관리자 인증)
+    // 주문 취소 API
+    // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/cancel")
     public ResponseEntity<CancelOrderResponse> cancelOrder(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody CancelOrderRequest request,
-            HttpSession session) {
+            HttpServletRequest httpRequest) {
 
-        LoginAdmin loginAdmin =
-                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+        Admin admin = extractAdmin(httpRequest);
 
-        CancelOrderResponse result = orderService.cancelOrder(orderId, request, loginAdmin);
+        CancelOrderResponse result = orderService.cancelOrder(orderId, request, admin);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,7 +1,10 @@
 package com.pcproject.order.controller;
 
+import com.pcproject.admin.controller.SessionConst;
+import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +22,16 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    // 주문 생성(POST)
+    // 주문 생성 (세션 기반 관리자 인증)
     @PostMapping
-    public ResponseEntity<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
-        CreateOrderResponse result = orderService.createOrder(request);
+    public ResponseEntity<CreateOrderResponse> createOrder(
+            @Valid @RequestBody CreateOrderRequest request,
+            HttpSession session) {
+
+        LoginAdmin loginAdmin =
+                (LoginAdmin) session.getAttribute(SessionConst.LOGIN_ADMIN);
+
+        CreateOrderResponse result = orderService.createOrder(request, loginAdmin);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 

--- a/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderRequest.java
@@ -4,12 +4,6 @@ package com.pcproject.order.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오후 3:34
- **/
 
 @Getter
 public class CancelOrderRequest {

--- a/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CancelOrderResponse.java
@@ -6,13 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오후 3:35
- **/
-
 
 @Getter
 public class CancelOrderResponse {

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -28,8 +28,4 @@ public class CreateOrderRequest {
     @NotNull
     @Min(1)
     private Integer quantity;
-
-    // 요청 or 인증 추출
-    // private Long adminId;
-
 }

--- a/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderRequest.java
@@ -8,12 +8,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 20.
- * Time: 오후 8:07
- **/
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/CreateOrderResponse.java
@@ -6,12 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 20.
- * Time: 오후 8:07
- **/
 
 @Getter
 public class CreateOrderResponse {

--- a/src/main/java/com/pcproject/order/dto/OrderSearchRequest.java
+++ b/src/main/java/com/pcproject/order/dto/OrderSearchRequest.java
@@ -1,6 +1,9 @@
 package com.pcproject.order.dto;
 
 import com.pcproject.order.entity.OrderStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,11 +14,23 @@ public class OrderSearchRequest {
     private static final int DEFAULT_SIZE = 10;
     private static final String DEFAULT_SORT_BY = "createdAt";
     private static final String DEFAULT_DIRECTION = "desc";
+    public static final int MIN_PAGE = 1;
+    public static final int MIN_SIZE = 1;
+    public static final int MAX_SIZE = 100;
 
     private String keyword;
     private OrderStatus status;
+
+    @Min(value = MIN_PAGE, message = "페이지 번호는 " + MIN_PAGE + " 이상이어야 합니다.")
     private int page = DEFAULT_PAGE;
+
+    @Min(value = MIN_SIZE, message = "페이지 크기는 " + MIN_SIZE + " 이상이어야 합니다.")
+    @Max(value = MAX_SIZE, message = "페이지 크기는 " + MAX_SIZE + " 이하이어야 합니다.")
     private int size = DEFAULT_SIZE;
+
+    @Pattern(regexp = "quantity|totalAmount|createdAt", message = "허용되지 않은 정렬 기준입니다.")
     private String sortBy = DEFAULT_SORT_BY;
+
+    @Pattern(regexp = "(?i)asc|desc", message = "정렬 순서는 asc 또는 desc만 허용됩니다.")
     private String direction = DEFAULT_DIRECTION;
 }

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderRequest.java
@@ -5,12 +5,6 @@ import com.pcproject.order.entity.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderRequest {

--- a/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
+++ b/src/main/java/com/pcproject/order/dto/UpdateOrderResponse.java
@@ -6,12 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-/**
- * Created by IntelliJ IDEA.
- * User: jeongjihun
- * Date: 26. 2. 23.
- * Time: 오전 10:44
- **/
 
 @Getter
 public class UpdateOrderResponse {

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -69,12 +69,6 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 주문 취소 메서드
-    public void cancel(String cancelReason) {
-        this.status = OrderStatus.CANCELLED;
-        this.cancelReason = cancelReason;
-        this.updatedAt = LocalDateTime.now();
-    }
 
     // 상태 전이 정책을 캡슐화한 메서드 (허용된 전이만 가능)
     public void changeStatus(OrderStatus target) {
@@ -99,4 +93,23 @@ public class Order {
         this.status = target;
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 주문 취소 정책 수행 (사유 검증 + PREPARING 상태만 허용)
+    public void cancel(String cancelReason) {
+
+        // 취소 사유는 필수 (도메인 무결성 보장)
+        if (cancelReason == null || cancelReason.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        // 취소는 PREPARING 상태에서만 가능
+        if (this.status != OrderStatus.PREPARING) {
+            throw new CustomException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        }
+
+        this.status = OrderStatus.CANCELLED;
+        this.cancelReason = cancelReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -4,8 +4,6 @@ import com.pcproject.admin.entity.Admin;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.pcproduct.entity.Product;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -55,8 +53,6 @@ public class Order {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
-
-    private LocalDateTime deletedAt;
 
     public Order(String orderNumber, Customer customer, Product product, Admin admin, Integer quantity, Long unitPrice, OrderStatus status) {
         this.orderNumber = orderNumber;

--- a/src/main/java/com/pcproject/order/entity/Order.java
+++ b/src/main/java/com/pcproject/order/entity/Order.java
@@ -2,6 +2,8 @@ package com.pcproject.order.entity;
 
 import com.pcproject.admin.entity.Admin;
 import com.pcproject.customer.entity.Customer;
+import com.pcproject.global.exception.CustomException;
+import com.pcproject.global.exception.ErrorCode;
 import com.pcproject.pcproduct.entity.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -67,16 +69,34 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    // 주문 상태 변경 메서드
-    public void updateStatus(OrderStatus status) {
-        this.status = status;
-        this.updatedAt = LocalDateTime.now();
-    }
-
     // 주문 취소 메서드
     public void cancel(String cancelReason) {
         this.status = OrderStatus.CANCELLED;
         this.cancelReason = cancelReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 상태 전이 정책을 캡슐화한 메서드 (허용된 전이만 가능)
+    public void changeStatus(OrderStatus target) {
+
+        if (target == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (this.status == OrderStatus.CANCELLED
+                || this.status == OrderStatus.DELIVERED) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        boolean valid =
+                (this.status == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
+                        (this.status == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
+
+        if (!valid) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        this.status = target;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pcproject/order/repository/OrderSpecification.java
+++ b/src/main/java/com/pcproject/order/repository/OrderSpecification.java
@@ -14,6 +14,9 @@ public class OrderSpecification {
     public static Specification<Order> searchByKeyword(String keyword) {
         return (root, query, criteriaBuilder) -> {
             if (keyword == null || keyword.trim().isEmpty()) return criteriaBuilder.conjunction(); // 키워드 비어있으면 전체 조회
+            if (query != null) {
+                query.distinct(true);
+            }
 
             Join<Order, Customer> customerJoin = root.join("customer", JoinType.LEFT); // 고객 정보 삭제 시에도 유지
 
@@ -28,6 +31,18 @@ public class OrderSpecification {
             if (status == null) return criteriaBuilder.conjunction(); // 상태 비어있으면 전체 조회
 
             return criteriaBuilder.equal(root.get("status"), status);
+        };
+    }
+
+    // N+1 방지 fetch join
+    public static Specification<Order> fetchAssociations() {
+        return (root, query, criteriaBuilder) -> {
+            if (query != null && Long.class != query.getResultType()) {
+                root.fetch("customer", JoinType.LEFT);
+                root.fetch("product", JoinType.LEFT);
+                root.fetch("admin", JoinType.LEFT);
+            }
+            return criteriaBuilder.conjunction();
         };
     }
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -102,32 +102,12 @@ public class OrderService {
     @Transactional
     public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
 
-        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        // 주문 조회(공통 에러 코드로 변경함)
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2) 최종 상태면 변경 불가(추후 공통 에러 코드로 변경 예정)
-        if (order.getStatus() == OrderStatus.CANCELLED || order.getStatus() == OrderStatus.DELIVERED) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        OrderStatus target = request.getStatus();
-        OrderStatus current = order.getStatus();
-
-        // 3) 허용된 전이만 통과
-        boolean isValid =
-                (current == OrderStatus.PREPARING && target == OrderStatus.SHIPPING) ||
-                        (current == OrderStatus.SHIPPING && target == OrderStatus.DELIVERED);
-
-        if (!isValid) {
-            throw new IllegalStateException("INVALID_ORDER_STATUS");
-        }
-
-        // 4) 상태 변경 + updatedAt 갱신
-        order.updateStatus(target);
-
-        // 5) 저장
-        orderRepository.save(order);
+        // 상태 전이 검증 및 변경은 도메인 정책에 따라 엔티티에서 처리
+        order.changeStatus(request.getStatus());
 
         return new UpdateOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -140,9 +140,9 @@ public class OrderService {
         // 취소 사유 검증 및 저장, 상태 변경은 도메인 정책에 따라 엔티티에서 처리
         order.cancel(request.getCancelReason());
 
-        // 4) TODO: 재고 복구 처리(추후 구현 예정)
-        // - 주문 수량만큼 product.stock += quantity
-        // - product.status 자동 전환 (단, DISCONTINUED면 상태 유지)
+        // 취소된 주문 수량만큼 상품 재고 복구 (상품 도메인 정책 적용)
+        Product product = order.getProduct();
+        product.restoreStock(order.getQuantity());
 
         return new CancelOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -62,18 +62,18 @@ public class OrderService {
         // CS 담당 관리자 검증
         Admin admin = validateCsAdmin(loginAdmin);
 
-        // 고객 id 검증 및 공통 에러 처리
-        Customer customer = customerRepository.findById(request.getCustomerId())
-                .orElseThrow(()-> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
-
-        // 상품 id 검증 및 공통 에러 처리
-        Product product = productRepository.findById(request.getProductId())
-                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-
         // DTO와 함께 quantity 중복 체크(혹시 모를 우회 완전 차단)
         if (request.getQuantity() < 1) {
             throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
         }
+
+        // 고객 조회
+        Customer customer = customerRepository.findById(request.getCustomerId())
+                .orElseThrow(()-> new CustomException(ErrorCode.CUSTOMER_NOT_FOUND));
+
+        // 상품 조회 (비관적 락 적용: 재고 동시성 제어)
+        Product product = productRepository.findByIdForUpdate(request.getProductId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         // 재고가 상태 검증 후 차감
         product.validateOrderable();

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -131,7 +131,19 @@ public class OrderService {
 
     // 주문 취소(PATCH)
     @Transactional
-    public CancelOrderResponse cancelOrder(Long orderId, CancelOrderRequest request) {
+    public CancelOrderResponse cancelOrder(
+            Long orderId,
+            CancelOrderRequest request,
+            LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -5,7 +5,6 @@ import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
 import com.pcproject.global.exception.CustomException;
 import com.pcproject.global.exception.ErrorCode;
-import com.pcproject.order.dto.*;
 import com.pcproject.order.entity.Order;
 import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
@@ -23,8 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
-
 
 @Service
 @RequiredArgsConstructor
@@ -159,34 +158,35 @@ public class OrderService {
 
 
     @Transactional(readOnly = true)
-    public OrderListResponse getOrders(String keyword, OrderStatus status, int page, int size, String sortBy, String direction) {
-        Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy); // asc(오름차순), desc(내림차순) 외 입력 시 예외
+    public OrderListResponse getOrders(OrderSearchRequest request) {
+        String keyword = request.getKeyword();
+        OrderStatus status = request.getStatus();
+        int page = request.getPage();
+        int size = request.getSize();
+        String sortBy = request.getSortBy();
+        String direction = request.getDirection();
+
+        Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
 
         Pageable pageable = PageRequest.of(page - 1, size, sort);
-
-        // 키워드 검색 + 상태 필터 조건 조합 (null이면 전체 조회)
         Specification<Order> spec = Specification
                 .where(OrderSpecification.searchByKeyword(keyword))
-                .and(OrderSpecification.filterByStatus(status));
+                .and(OrderSpecification.filterByStatus(status))
+                .and(OrderSpecification.fetchAssociations());
 
         Page<Order> orders = orderRepository.findAll(spec, pageable);
 
         List<OrderResponse> content = orders.getContent().stream()
                 .map(OrderResponse::from)
                 .toList();
-
         PageInfoResponse pageInfo = PageInfoResponse.from(orders);
-
         return new OrderListResponse(content, pageInfo);
     }
 
     @Transactional(readOnly = true)
     public OrderDetailResponse getOrder(Long id) {
-
         Order order = orderRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
         return OrderDetailResponse.from(order);
     }
-
 }

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -38,7 +38,9 @@ public class OrderService {
 
     // 주문 생성(POST)
     @Transactional
-    public CreateOrderResponse createOrder(CreateOrderRequest request, LoginAdmin loginAdmin) {
+    public CreateOrderResponse createOrder(
+            CreateOrderRequest request,
+            LoginAdmin loginAdmin) {
 
         // 세션 로그인 검증
         if (loginAdmin == null) {
@@ -100,7 +102,19 @@ public class OrderService {
 
     // 주문 상태 변경(PATCH)
     @Transactional
-    public UpdateOrderResponse updateOrderStatus(Long orderId, UpdateOrderRequest request) {
+    public UpdateOrderResponse updateOrderStatus(
+            Long orderId,
+            UpdateOrderRequest request,
+            LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 주문 조회(공통 에러 코드로 변경함)
         Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -2,8 +2,6 @@ package com.pcproject.order.service;
 
 import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.admin.entity.Admin;
-import com.pcproject.admin.entity.AdminRole;
-import com.pcproject.admin.repository.AdminRepository;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
@@ -33,39 +31,13 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CustomerRepository customerRepository;
     private final ProductRepository productRepository;
-    private final AdminRepository adminRepository;
 
-    // CS 담당 관리자 인증 및 인가 검증 후 Admin 반환
-    private Admin validateCsAdmin(LoginAdmin loginAdmin) {
-
-        // 세션 로그인 검증
-        if (loginAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // 권한 검증(CS_ADMIN)
-        if (loginAdmin.getRole() != AdminRole.CS_ADMIN) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        // Admin 조회
-        return adminRepository.findById(loginAdmin.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-    }
 
     // 주문 생성(POST)
     @Transactional
     public CreateOrderResponse createOrder(
             CreateOrderRequest request,
-            LoginAdmin loginAdmin) {
-
-        // CS 담당 관리자 검증
-        Admin admin = validateCsAdmin(loginAdmin);
-
-        // DTO와 함께 quantity 중복 체크(혹시 모를 우회 완전 차단)
-        if (request.getQuantity() < 1) {
-            throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
-        }
+            Admin admin) {
 
         // 고객 조회
         Customer customer = customerRepository.findById(request.getCustomerId())
@@ -75,7 +47,8 @@ public class OrderService {
         Product product = productRepository.findByIdForUpdate(request.getProductId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        // 재고가 상태 검증 후 차감
+        // 판매 가능 상태 및 삭제 여부 검증
+        // 재고 부족 여부를 도메인 내부에서 검증 후 차감
         product.validateOrderable();
         product.decreaseStock(request.getQuantity());
 
@@ -116,9 +89,7 @@ public class OrderService {
     public UpdateOrderResponse updateOrderStatus(
             Long orderId,
             UpdateOrderRequest request,
-            LoginAdmin loginAdmin) {
-
-        validateCsAdmin(loginAdmin);
+            Admin admin) {
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
@@ -139,9 +110,7 @@ public class OrderService {
     public CancelOrderResponse cancelOrder(
             Long orderId,
             CancelOrderRequest request,
-            LoginAdmin loginAdmin) {
-
-        validateCsAdmin(loginAdmin);
+            Admin admin) {
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -1,5 +1,8 @@
 package com.pcproject.order.service;
 
+import com.pcproject.admin.dto.LoginAdmin;
+import com.pcproject.admin.entity.Admin;
+import com.pcproject.admin.repository.AdminRepository;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.customer.repository.CustomerRepository;
 import com.pcproject.order.dto.*;
@@ -31,10 +34,20 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CustomerRepository customerRepository;
     private final ProductRepository productRepository;
+    private final AdminRepository adminRepository;
 
     // 주문 생성(POST)
     @Transactional
-    public CreateOrderResponse createOrder(CreateOrderRequest request) {
+    public CreateOrderResponse createOrder(CreateOrderRequest request, LoginAdmin loginAdmin) {
+
+        // 세션 로그인 검증
+        if (loginAdmin == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // Admin 조회
+        Admin admin = adminRepository.findById(loginAdmin.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         // 고객 id 검증 및 공통 에러 처리
         Customer customer = customerRepository.findById(request.getCustomerId())
@@ -61,12 +74,12 @@ public class OrderService {
         // 상품 가격 스냅샷
         Long unitPrice = product.getPrice();
 
-        // 관리자 Id 임시로 null값 넣음
+        // 주문 생성 (로그인 관리자 정보 포함)
         Order order = new Order(
                 orderNumber,
                 customer,
                 product,
-                null,
+                admin,
                 request.getQuantity(),
                 unitPrice,
                 OrderStatus.PREPARING

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -50,22 +50,8 @@ public class OrderService {
             throw new CustomException(ErrorCode.ORDER_QUANTITY_INVALID);
         }
 
-        // 상품 삭제 여부 검증
-        if (product.getDeletedAt() != null) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
-        }
-
-        // 판매 상태가 ON_SALE인지 확인
-        if (product.getStatus() != ProductStatus.ON_SALE) {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
-        }
-
-        //
-        if (product.getStock() < request.getQuantity()) {
-            throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
-        }
-
-        // 재고가 있는지 검증 후 차감
+        // 재고가 상태 검증 후 차감
+        product.validateOrderable();
         product.decreaseStock(request.getQuantity());
 
         // 주문번호(임시) ORD-생성시간-랜덤
@@ -73,8 +59,8 @@ public class OrderService {
                 "ORD-" + System.currentTimeMillis()
                 + "-" + UUID.randomUUID().toString().substring(0, 4);
 
-        // 상품 가격(임시)
-        Long unitPrice = 10000L;
+        // 상품 가격 스냅샷
+        Long unitPrice = product.getPrice();
 
         // 관리자 Id 임시로 null값 넣음
         Order order = new Order(

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -2,6 +2,7 @@ package com.pcproject.order.service;
 
 import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.admin.entity.Admin;
+import com.pcproject.admin.entity.AdminRole;
 import com.pcproject.admin.repository.AdminRepository;
 import com.pcproject.customer.entity.Customer;
 import com.pcproject.customer.repository.CustomerRepository;
@@ -24,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -35,20 +35,32 @@ public class OrderService {
     private final ProductRepository productRepository;
     private final AdminRepository adminRepository;
 
-    // 주문 생성(POST)
-    @Transactional
-    public CreateOrderResponse createOrder(
-            CreateOrderRequest request,
-            LoginAdmin loginAdmin) {
+    // CS 담당 관리자 인증 및 인가 검증 후 Admin 반환
+    private Admin validateCsAdmin(LoginAdmin loginAdmin) {
 
         // 세션 로그인 검증
         if (loginAdmin == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
+        // 권한 검증(CS_ADMIN)
+        if (loginAdmin.getRole() != AdminRole.CS_ADMIN) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
         // Admin 조회
-        Admin admin = adminRepository.findById(loginAdmin.getId())
+        return adminRepository.findById(loginAdmin.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+    }
+
+    // 주문 생성(POST)
+    @Transactional
+    public CreateOrderResponse createOrder(
+            CreateOrderRequest request,
+            LoginAdmin loginAdmin) {
+
+        // CS 담당 관리자 검증
+        Admin admin = validateCsAdmin(loginAdmin);
 
         // 고객 id 검증 및 공통 에러 처리
         Customer customer = customerRepository.findById(request.getCustomerId())
@@ -106,14 +118,7 @@ public class OrderService {
             UpdateOrderRequest request,
             LoginAdmin loginAdmin) {
 
-        // 세션 로그인 검증
-        if (loginAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // Admin 조회
-        adminRepository.findById(loginAdmin.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+        validateCsAdmin(loginAdmin);
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
@@ -136,23 +141,16 @@ public class OrderService {
             CancelOrderRequest request,
             LoginAdmin loginAdmin) {
 
-        // 세션 로그인 검증
-        if (loginAdmin == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // Admin 조회
-        adminRepository.findById(loginAdmin.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+        validateCsAdmin(loginAdmin);
 
         // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 취소 사유 검증 및 저장, 상태 변경은 도메인 정책에 따라 엔티티에서 처리
+        // 주문 취소 정책은 Order 도메인에서 처리
         order.cancel(request.getCancelReason());
 
-        // 취소된 주문 수량만큼 상품 재고 복구 (상품 도메인 정책 적용)
+        // 취소 수량만큼 재고 복구 (Product 도메인 정책 적용)
         Product product = order.getProduct();
         product.restoreStock(order.getQuantity());
 

--- a/src/main/java/com/pcproject/order/service/OrderService.java
+++ b/src/main/java/com/pcproject/order/service/OrderService.java
@@ -13,7 +13,6 @@ import com.pcproject.order.entity.OrderStatus;
 import com.pcproject.order.repository.OrderRepository;
 import com.pcproject.order.repository.OrderSpecification;
 import com.pcproject.pcproduct.entity.Product;
-import com.pcproject.pcproduct.entity.ProductStatus;
 import com.pcproject.pcproduct.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -116,7 +115,7 @@ public class OrderService {
         adminRepository.findById(loginAdmin.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
-        // 주문 조회(공통 에러 코드로 변경함)
+        // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
@@ -130,30 +129,20 @@ public class OrderService {
         );
     }
 
-
-
     // 주문 취소(PATCH)
     @Transactional
     public CancelOrderResponse cancelOrder(Long orderId, CancelOrderRequest request) {
 
-        // 1) 주문 조회(추후 공통 에러 코드로 변경 예정)
+        // 주문 존재 여부 검증
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("ORDER_NOT_FOUND"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2) PREPARING만 취소 가능(추후 공통 에러 코드로 변경 예정)
-        if (order.getStatus() != OrderStatus.PREPARING) {
-            throw new IllegalStateException("ORDER_CANCEL_NOT_ALLOWED");
-        }
-
-        // 3) 취소 사유 저장 + 상태 변경
+        // 취소 사유 검증 및 저장, 상태 변경은 도메인 정책에 따라 엔티티에서 처리
         order.cancel(request.getCancelReason());
 
         // 4) TODO: 재고 복구 처리(추후 구현 예정)
         // - 주문 수량만큼 product.stock += quantity
         // - product.status 자동 전환 (단, DISCONTINUED면 상태 유지)
-
-        // 5) 저장
-        orderRepository.save(order);
 
         return new CancelOrderResponse(
                 order.getId(),

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -104,4 +104,28 @@ public class Product {
 
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 재고 복구 메서드
+    public void restoreStock(int quantity) {
+
+        if (quantity <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        this.stock += quantity;
+
+        // 단종(DISCONTINUED) 상품은 재고만 복구하고 상태는 변경하지 않음
+        if (this.status == ProductStatus.DISCONTINUED) {
+            this.updatedAt = LocalDateTime.now();
+            return;
+        }
+
+        // SOLD_OUT 상태에서 재고가 1 이상이면 ON_SALE로 전환
+        if (this.status == ProductStatus.SOLD_OUT && this.stock > 0) {
+            this.status = ProductStatus.ON_SALE;
+        }
+
+        this.updatedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/pcproject/pcproduct/entity/Product.java
+++ b/src/main/java/com/pcproject/pcproduct/entity/Product.java
@@ -75,11 +75,33 @@ public class Product {
         return deletedAt != null;
     }
 
+
+    // 재고 상태 검증
+    public void validateOrderable() {
+
+        // 상품 삭제 여부 검증
+        if (this.isDeleted()) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 판매 상태가 ON_SALE인지 확인
+        if (this.status != ProductStatus.ON_SALE) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_ON_SALE);
+        }
+    }
+
     // 재고 검증과 차감 메서드
     public void decreaseStock(int quantity) {
         if (this.stock < quantity) {
             throw new CustomException(ErrorCode.PRODUCT_STOCK_INSUFFICIENT);
         }
         this.stock -= quantity;
+
+        // 재고가 0이 되면 자동으로 SOLD_OUT 전환
+        if (this.stock == 0 && this.status == ProductStatus.ON_SALE) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/pcproject/pcproduct/repository/ProductRepository.java
+++ b/src/main/java/com/pcproject/pcproduct/repository/ProductRepository.java
@@ -2,6 +2,19 @@ package com.pcproject.pcproduct.repository;
 
 import com.pcproject.pcproduct.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    // 비관적 락(PESSIMISTIC_WRITE)을 적용한 상품 조회 메서드
+    // 재고 차감 시 동시성 제어 목적
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdForUpdate(@Param("id") Long id);
 }


### PR DESCRIPTION
Summary
- 주문 CUD(Create / Update / Cancel) API에 대해 관리자 인증/인가 로직을 Interceptor 기반으로 분리했습니다.
- HttpSession 기반 로그인 검증 및 CS_ADMIN 권한 검증을 공통 처리하도록 구현했습니다.
- 인증 책임을 Service 레이어에서 제거하고 Web 계층으로 이동시켜 관심사 분리(Separation of Concerns)를 강화했습니다.

Closes #58

Changes
1. AdminAuthInterceptor 신규 구현
- HandlerInterceptor 구현
- 세션 존재 여부 검증 (getSession(false))
- 로그인 관리자(LoginAdmin) 존재 여부 검증
- CS_ADMIN 권한 검증
- DB에서 실제 Admin 엔티티 재조회 (세션 DTO 직접 신뢰하지 않음)
- 인증 성공 시 request.setAttribute("admin", admin) 저장

2. WebConfig 설정 추가
- /api/orders의 CUD 경로(POST, PATCH)에 인터셉터 적용
- 조회(GET) API는 보호 대상에서 제외
- 인증 정책을 WebConfig에서 중앙 관리하도록 변경

3. OrderService 인증 코드 제거
- 기존 validateCsAdmin() 메서드 제거
- Service에서 세션/권한 검증 로직 제거
- Service는 순수 비즈니스 로직만 수행하도록 구조 개선

4. Controller 수정
- HttpServletRequest에서 admin attribute 추출
- 공통 extractAdmin() 메서드로 중복 제거
- Service에는 인증 정보(Admin)만 전달

참고 사항
- 인증 방식: HttpSession
- 권한 정책: CS_ADMIN만 주문 CUD 접근 가능
- 인증 실패 → 401 UNAUTHORIZED
- 권한 부족 → 403 FORBIDDEN