### PR TITLE
refactor: 주문 응답 형식 통일 및 주문 조회 인터셉터 누락 수정 #64

### DIFF
--- a/src/main/java/com/pcproject/global/config/WebConfig.java
+++ b/src/main/java/com/pcproject/global/config/WebConfig.java
@@ -18,11 +18,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
 
         registry.addInterceptor(adminAuthInterceptor)
-                // 주문 생성
-                .addPathPatterns("/api/orders")
-                // 상태 변경
-                .addPathPatterns("/api/orders/*/status")
-                // 주문 취소
-                .addPathPatterns("/api/orders/*/cancel");
+                .addPathPatterns("/api/orders/**");
     }
 }

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,14 +1,12 @@
 package com.pcproject.order.controller;
 
-import com.pcproject.admin.controller.SessionConst;
-import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.admin.entity.Admin;
 import com.pcproject.global.exception.CustomException;
 import com.pcproject.global.exception.ErrorCode;
+import com.pcproject.global.response.ApiResponse;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -38,55 +36,44 @@ public class OrderController {
     // 주문 생성 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PostMapping
-    public ResponseEntity<CreateOrderResponse> createOrder(
+    public ResponseEntity<ApiResponse<CreateOrderResponse>> createOrder(
             @Valid @RequestBody CreateOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        CreateOrderResponse result = orderService.createOrder(request, admin);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("주문 생성 완료", orderService.createOrder(request, admin)));
     }
 
     // 주문 상태 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/status")
-    public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
+    public ResponseEntity<ApiResponse<UpdateOrderResponse>> updateOrderStatus(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody UpdateOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, admin);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        return ResponseEntity.ok(ApiResponse.success("주문 상태 변경 완료", orderService.updateOrderStatus(orderId, request, admin)));
     }
 
     // 주문 취소 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/cancel")
-    public ResponseEntity<CancelOrderResponse> cancelOrder(
+    public ResponseEntity<ApiResponse<CancelOrderResponse>> cancelOrder(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody CancelOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        CancelOrderResponse result = orderService.cancelOrder(orderId, request, admin);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        return ResponseEntity.ok(ApiResponse.success("주문 취소 완료", orderService.cancelOrder(orderId, request, admin)));
     }
+
 
 
     @GetMapping
-    public ResponseEntity<OrderListResponse> getOrders(@Valid OrderSearchRequest request) {
-        OrderListResponse response = orderService.getOrders(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(@ModelAttribute @Valid OrderSearchRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("주문 목록 조회 성공", orderService.getOrders(request)));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<OrderDetailResponse> getOrder(@PathVariable Long orderId) {
-        OrderDetailResponse response = orderService.getOrder(orderId);
-        return ResponseEntity.ok(response);
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(@PathVariable Long orderId) {
+        return ResponseEntity.ok(ApiResponse.success("주문 상세 조회 성공", orderService.getOrder(orderId)));
     }
 }


### PR DESCRIPTION
**Summary**
- 컨트롤러 응답 형식 통일 및 주문 조회 API 인터셉터 누락 수정
- Closes #64 

**Changes**
- `OrderController`: 응답 타입을 ResponseEntity<DTO>에서 ResponseEntity<ApiResponse<T>>로 통일, 각 API 성공 메시지 추가
- `WebConfig`: 주문 조회 API(GET /api/orders, GET /api/orders/{orderId}) 인터셉터 누락 수정, 경로 패턴을 /api/orders/**로 통일