### PR TITLE
refactor: 컨트롤러 응답 형식 통일 #64 #66 #70

### DIFF
--- a/src/main/java/com/pcproject/customer/controller/CustomerController.java
+++ b/src/main/java/com/pcproject/customer/controller/CustomerController.java
@@ -2,6 +2,7 @@ package com.pcproject.customer.controller;
 
 import com.pcproject.customer.dto.*;
 import com.pcproject.customer.service.CustomerService;
+import com.pcproject.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -17,34 +18,36 @@ public class CustomerController {
     private final CustomerService customerService;
 
     @GetMapping
-    public ResponseEntity<GetCustomerListResponse> getCustomers(
-            @RequestParam(defaultValue = "") String keyword,
+    public ResponseEntity<ApiResponse<GetCustomerListResponse>> getCustomers(
+            @Valid @ModelAttribute CustomerSearchRequest request,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(customerService.getCustomers(keyword, pageable));
+        return ResponseEntity.ok(ApiResponse.success("고객 목록 조회 성공", customerService.getCustomers(request.getKeyword(), pageable)));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<GetCustomerResponse> getCustomer(@PathVariable Long id) {
-        return ResponseEntity.ok(customerService.getCustomer(id));
+    @GetMapping("/{customerId}")
+    public ResponseEntity<ApiResponse<GetCustomerResponse>> getCustomer(
+            @PathVariable Long customerId) {
+        return ResponseEntity.ok(ApiResponse.success("고객 상세 조회 성공", customerService.getCustomer(customerId)));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<UpdateCustomerInfoResponse> updateInfo(
-            @PathVariable Long id,
+    @PutMapping("/{customerId}")
+    public ResponseEntity<ApiResponse<UpdateCustomerInfoResponse>> updateInfo(
+            @PathVariable Long customerId,
             @Valid @RequestBody UpdateCustomerInfoRequest request) {
-        return ResponseEntity.ok(customerService.updateInfo(id, request));
+        return ResponseEntity.ok(ApiResponse.success("고객 정보 수정 완료", customerService.updateInfo(customerId, request)));
     }
 
-    @PatchMapping("/{id}/status")
-    public ResponseEntity<UpdateCustomerStatusResponse> updateStatus(
-            @PathVariable Long id,
+    @PatchMapping("/{customerId}/status")
+    public ResponseEntity<ApiResponse<UpdateCustomerStatusResponse>> updateStatus(
+            @PathVariable Long customerId,
             @Valid @RequestBody UpdateCustomerStatusRequest request) {
-        return ResponseEntity.ok(customerService.updateStatus(id, request));
+        return ResponseEntity.ok(ApiResponse.success("고객 상태 변경 완료", customerService.updateStatus(customerId, request)));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteCustomer(@PathVariable Long id) {
-        customerService.deleteCustomer(id);
-        return ResponseEntity.noContent().build();
+    @DeleteMapping("/{customerId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCustomer(
+            @PathVariable Long customerId) {
+        customerService.deleteCustomer(customerId);
+        return ResponseEntity.ok(ApiResponse.success("고객 삭제 완료", null));
     }
 }

--- a/src/main/java/com/pcproject/customer/dto/CustomerSearchRequest.java
+++ b/src/main/java/com/pcproject/customer/dto/CustomerSearchRequest.java
@@ -1,0 +1,36 @@
+package com.pcproject.customer.dto;
+
+import com.pcproject.customer.entity.CustomerStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CustomerSearchRequest {
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_SIZE = 10;
+    private static final String DEFAULT_SORT_BY = "createdAt";
+    private static final String DEFAULT_DIRECTION = "desc";
+    public static final int MIN_PAGE = 1;
+    public static final int MIN_SIZE = 1;
+    public static final int MAX_SIZE = 100;
+
+    private String keyword = "";
+    private CustomerStatus status;
+
+    @Min(value = MIN_PAGE, message = "페이지 번호는 " + MIN_PAGE + " 이상이어야 합니다.")
+    private int page = DEFAULT_PAGE;
+
+    @Min(value = MIN_SIZE, message = "페이지 크기는 " + MIN_SIZE + " 이상이어야 합니다.")
+    @Max(value = MAX_SIZE, message = "페이지 크기는 " + MAX_SIZE + " 이하이어야 합니다.")
+    private int size = DEFAULT_SIZE;
+
+    @Pattern(regexp = "name|email|createdAt", message = "허용되지 않은 정렬 기준입니다.")
+    private String sortBy = DEFAULT_SORT_BY;
+
+    @Pattern(regexp = "(?i)asc|desc", message = "정렬 순서는 asc 또는 desc만 허용됩니다.")
+    private String direction = DEFAULT_DIRECTION;
+}

--- a/src/main/java/com/pcproject/global/config/WebConfig.java
+++ b/src/main/java/com/pcproject/global/config/WebConfig.java
@@ -18,11 +18,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
 
         registry.addInterceptor(adminAuthInterceptor)
-                // 주문 생성
-                .addPathPatterns("/api/orders")
-                // 상태 변경
-                .addPathPatterns("/api/orders/*/status")
-                // 주문 취소
-                .addPathPatterns("/api/orders/*/cancel");
+                .addPathPatterns("/api/orders/**");
     }
 }

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -1,14 +1,12 @@
 package com.pcproject.order.controller;
 
-import com.pcproject.admin.controller.SessionConst;
-import com.pcproject.admin.dto.LoginAdmin;
 import com.pcproject.admin.entity.Admin;
 import com.pcproject.global.exception.CustomException;
 import com.pcproject.global.exception.ErrorCode;
+import com.pcproject.global.response.ApiResponse;
 import com.pcproject.order.dto.*;
 import com.pcproject.order.service.OrderService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -38,55 +36,44 @@ public class OrderController {
     // 주문 생성 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PostMapping
-    public ResponseEntity<CreateOrderResponse> createOrder(
+    public ResponseEntity<ApiResponse<CreateOrderResponse>> createOrder(
             @Valid @RequestBody CreateOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        CreateOrderResponse result = orderService.createOrder(request, admin);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("주문 생성 완료", orderService.createOrder(request, admin)));
     }
 
     // 주문 상태 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/status")
-    public ResponseEntity<UpdateOrderResponse> updateOrderStatus(
+    public ResponseEntity<ApiResponse<UpdateOrderResponse>> updateOrderStatus(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody UpdateOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        UpdateOrderResponse result = orderService.updateOrderStatus(orderId, request, admin);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        return ResponseEntity.ok(ApiResponse.success("주문 상태 변경 완료", orderService.updateOrderStatus(orderId, request, admin)));
     }
 
     // 주문 취소 API
     // 인증/인가 검증은 Interceptor에서 수행됨
     @PatchMapping("/{orderId}/cancel")
-    public ResponseEntity<CancelOrderResponse> cancelOrder(
+    public ResponseEntity<ApiResponse<CancelOrderResponse>> cancelOrder(
             @PathVariable @Positive Long orderId,
             @Valid @RequestBody CancelOrderRequest request,
             HttpServletRequest httpRequest) {
-
         Admin admin = extractAdmin(httpRequest);
-
-        CancelOrderResponse result = orderService.cancelOrder(orderId, request, admin);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        return ResponseEntity.ok(ApiResponse.success("주문 취소 완료", orderService.cancelOrder(orderId, request, admin)));
     }
+
 
 
     @GetMapping
-    public ResponseEntity<OrderListResponse> getOrders(@Valid OrderSearchRequest request) {
-        OrderListResponse response = orderService.getOrders(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(@ModelAttribute @Valid OrderSearchRequest request) {
+        return ResponseEntity.ok(ApiResponse.success("주문 목록 조회 성공", orderService.getOrders(request)));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<OrderDetailResponse> getOrder(@PathVariable Long orderId) {
-        OrderDetailResponse response = orderService.getOrder(orderId);
-        return ResponseEntity.ok(response);
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(@PathVariable Long orderId) {
+        return ResponseEntity.ok(ApiResponse.success("주문 상세 조회 성공", orderService.getOrder(orderId)));
     }
 }

--- a/src/main/java/com/pcproject/order/controller/OrderController.java
+++ b/src/main/java/com/pcproject/order/controller/OrderController.java
@@ -65,15 +65,19 @@ public class OrderController {
         return ResponseEntity.ok(ApiResponse.success("주문 취소 완료", orderService.cancelOrder(orderId, request, admin)));
     }
 
-
-
     @GetMapping
-    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(@ModelAttribute @Valid OrderSearchRequest request) {
+    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders(
+            @ModelAttribute @Valid OrderSearchRequest request,
+            HttpServletRequest httpRequest) {
+        extractAdmin(httpRequest);
         return ResponseEntity.ok(ApiResponse.success("주문 목록 조회 성공", orderService.getOrders(request)));
     }
 
     @GetMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(@PathVariable Long orderId) {
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(
+            @PathVariable Long orderId,
+            HttpServletRequest httpRequest) {
+        extractAdmin(httpRequest);
         return ResponseEntity.ok(ApiResponse.success("주문 상세 조회 성공", orderService.getOrder(orderId)));
     }
 }


### PR DESCRIPTION
**Summary**
- 컨트롤러 응답 형식 통일 및 주문 조회 API 인터셉터 누락 수정
- Closes #64
- Closes #66 
- Closes #70 

**Changes**

- `CustomerController`: 응답 타입을 ResponseEntity<DTO>에서 ResponseEntity<ApiResponse<T>>로 통일, 각 API 성공 메시지 추가
- `OrderController`: 응답 타입을 ResponseEntity에서 ResponseEntity<ApiResponse>로 통일, 각 API 성공 메시지 추가, 주문 목록/상세 조회 API에 extractAdmin() 추가
- `WebConfig`: 주문 조회 API(GET /api/orders, GET /api/orders/{orderId}) 인터셉터 누락 수정, 경로 패턴을 /api/orders/**로 통일
- `CustomerSearchRequest`: 신규 DTO 추가